### PR TITLE
Fix `default` option for `created_at` column to allow SQL expression

### DIFF
--- a/server/src/entity/Player.ts
+++ b/server/src/entity/Player.ts
@@ -44,7 +44,7 @@ export class Player {
   pass: string;
 
   @Column({
-    default: 'CURRENT_TIMESTAMP',
+    default: () => 'CURRENT_TIMESTAMP',
     name: 'created_at',
     nullable: false,
     type: 'timestamptz',


### PR DESCRIPTION
This update fixes my original commit that tried to simply use the SQL expression as a string. Per [this TypeORM issue](https://github.com/typeorm/typeorm/issues/877) I have to use a function that returns the SQL expression instead.