### PR TITLE
Create remaining tables/entities for db and establish relations

### DIFF
--- a/server/src/dto/player.dto.ts
+++ b/server/src/dto/player.dto.ts
@@ -1,8 +1,0 @@
-export class CreatePlayerDto {
-  readonly firstName: string;
-  readonly id: number;
-  readonly lastName: string;
-  readonly skillLevel: number;
-  readonly teamCaptain: number;
-  readonly teamId: number;
-}

--- a/server/src/entity/Division.ts
+++ b/server/src/entity/Division.ts
@@ -1,0 +1,51 @@
+import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+
+import { Team } from './Team';
+
+@Entity()
+export class Division {
+  @PrimaryColumn({
+    name: 'division_id',
+    nullable: false,
+    type: 'int',
+  })
+  public divisionId: number;
+
+  @Column({
+    length: 25,
+    nullable: false,
+  })
+  public name: string;
+
+  @Column({
+    name: 'day_of_week',
+    nullable: false,
+    type: 'smallint',
+  })
+  public dayOfWeek: number;
+
+  @Column({
+    length: 20,
+    nullable: false,
+  })
+  public format: string;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @OneToMany(type => Team, team => team.division)
+  public teams: Team[];
+}

--- a/server/src/entity/Game.ts
+++ b/server/src/entity/Game.ts
@@ -1,0 +1,76 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Match } from './Match';
+import { PlayerGame } from './PlayerGame';
+
+@Entity()
+export class Game {
+  @PrimaryGeneratedColumn({
+    name: 'game_id',
+    type: 'int',
+  })
+  public gameId: number;
+
+  @Column({
+    name: 'start_time',
+    nullable: false,
+    type: 'time',
+  })
+  public startTime: Date;
+
+  @Column({
+    default: null,
+    name: 'end_time',
+    nullable: true,
+    type: 'time',
+  })
+  public endTime: Date;
+
+  @Column({
+    default: 0,
+    name: 'dead_balls',
+    nullable: false,
+    type: 'smallint',
+  })
+  public deadBalls: number;
+
+  @Column({
+    default: 0,
+    nullable: false,
+    type: 'smallint',
+  })
+  public innings: number;
+
+  @Column({
+    default: false,
+    name: 'post_season',
+    nullable: false,
+    type: 'boolean',
+  })
+  public postSeason: boolean;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @ManyToOne(type => Match, match => match.games)
+  @JoinColumn({
+    name: 'match_id',
+  })
+  public matchId: Match;
+
+  @OneToMany(type => PlayerGame, playerGame => playerGame.gameId)
+  public players: PlayerGame[];
+}

--- a/server/src/entity/HostLocation.ts
+++ b/server/src/entity/HostLocation.ts
@@ -1,0 +1,71 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Team } from './Team';
+
+@Entity('host_location')
+export class HostLocation {
+  @PrimaryGeneratedColumn({
+    name: 'location_id',
+    type: 'int',
+  })
+  public locationId: number;
+
+  @Column({
+    length: 30,
+    nullable: false,
+  })
+  public name: string;
+
+  @Column({
+    length: 100,
+    nullable: false,
+  })
+  public address: string;
+
+  @Column({
+    length: 20,
+    nullable: false,
+  })
+  public city: string;
+
+  @Column({
+    length: 2,
+    nullable: false,
+  })
+  public state: string;
+
+  @Column({
+    name: 'zip_code',
+    nullable: false,
+    type: 'int',
+  })
+  public zipCode: number;
+
+  @Column({
+    name: 'phone_number',
+    nullable: false,
+    precision: 10,
+    scale: 0,
+    type: 'numeric',
+  })
+  public phoneNumber: number;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @OneToMany(type => Team, team => team.hostLocation)
+  public teams: Team[];
+}

--- a/server/src/entity/Match.ts
+++ b/server/src/entity/Match.ts
@@ -1,0 +1,80 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Game } from './Game';
+import { Session } from './Session';
+import { TeamMatch } from './TeamMatch';
+
+@Entity()
+export class Match {
+  @PrimaryGeneratedColumn({
+    name: 'match_id',
+    type: 'int',
+  })
+  public matchId: number;
+
+  @Column({
+    default: () => 'CURRENT_DATE',
+    name: 'match_date',
+    nullable: false,
+    type: 'date',
+  })
+  public matchDate: Date;
+
+  @Column({
+    name: 'start_time',
+    nullable: false,
+    type: 'time',
+  })
+  public startTime: Date;
+
+  @Column({
+    default: null,
+    name: 'end_time',
+    nullable: true,
+    type: 'time',
+  })
+  public endTime: Date;
+
+  @Column({
+    name: 'week_number',
+    nullable: false,
+    type: 'smallint',
+  })
+  public weekNumber: number;
+
+  @Column({
+    default: false,
+    name: 'post_season',
+    nullable: false,
+    type: 'boolean',
+  })
+  public postSeason: boolean;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @ManyToOne(type => Session, session => session.matches)
+  @JoinColumn({
+    name: 'session',
+  })
+  public session: Session;
+
+  @OneToMany(type => Game, game => game.matchId)
+  public games: Game[];
+
+  @OneToMany(type => TeamMatch, teamMatch => teamMatch.matchId)
+  public teams: TeamMatch[];
+}

--- a/server/src/entity/Player.ts
+++ b/server/src/entity/Player.ts
@@ -1,5 +1,7 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm';
 
+import { PlayerGame } from './PlayerGame';
+import { PlayerTeam } from './PlayerTeam';
 import { SkillLevel } from './SkillLevel';
 
 @Entity()
@@ -9,33 +11,33 @@ export class Player {
     nullable: false,
     type: 'int',
   })
-  playerId: number;
+  public playerId: number;
 
   @Column({
     length: 25,
     name: 'first_name',
     nullable: false,
   })
-  firstName: string;
+  public firstName: string;
 
   @Column({
     length: 50,
     name: 'last_name',
     nullable: false,
   })
-  lastName: string;
+  public lastName: string;
 
   @Column({
     length: 50,
     nullable: false,
   })
-  email: string;
+  public email: string;
 
   @Column({
     length: 50,
     nullable: false,
   })
-  pass: string;
+  public pass: string;
 
   @Column({
     default: () => 'CURRENT_TIMESTAMP',
@@ -43,11 +45,25 @@ export class Player {
     nullable: false,
     type: 'timestamptz',
   })
-  createdAt: Date;
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
 
   @ManyToOne(type => SkillLevel, skillLevel => skillLevel.players)
   @JoinColumn({
     name: 'skill_level',
   })
-  skillLevel: SkillLevel;
+  public skillLevel: SkillLevel;
+
+  @OneToMany(type => PlayerGame, playerGame => playerGame.playerId)
+  public games: PlayerGame[];
+
+  @OneToMany(type => PlayerTeam, playerTeam => playerTeam.playerId)
+  public teams: PlayerTeam[];
 }

--- a/server/src/entity/PlayerGame.ts
+++ b/server/src/entity/PlayerGame.ts
@@ -1,0 +1,95 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { Game } from './Game';
+import { Player } from './Player';
+
+@Entity('player_game')
+export class PlayerGame {
+  @Column({
+    default: 0,
+    name: 'points_scored',
+    nullable: false,
+    type: 'smallint',
+  })
+  public pointsScored: number;
+
+  @Column({
+    default: 0,
+    name: 'player_score',
+    nullable: false,
+    type: 'smallint',
+  })
+  public playerScore: number;
+
+  @Column({
+    default: 0,
+    nullable: false,
+    type: 'smallint',
+  })
+  public defense: number;
+
+  @Column({
+    default: 0,
+    nullable: false,
+    type: 'smallint',
+  })
+  public timeout: number;
+
+  @Column({
+    default: 0,
+    name: 'break_and_run',
+    nullable: false,
+    type: 'smallint',
+  })
+  public breakAndRun: number;
+
+  @Column({
+    default: 0,
+    name: 'nine_on_snap',
+    nullable: false,
+    type: 'smallint',
+  })
+  public nineOnSnap: number;
+
+  @Column({
+    default: false,
+    nullable: false,
+    type: 'boolean',
+  })
+  public skunk: boolean;
+
+  @Column({
+    default: false,
+    nullable: false,
+    type: 'boolean',
+  })
+  public won: boolean;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @ManyToOne(type => Game, game => game.players, { primary: true })
+  @JoinColumn({
+    name: 'game_id',
+  })
+  public gameId: Game;
+
+  @ManyToOne(type => Player, player => player.games, { primary: true })
+  @JoinColumn({
+    name: 'player_id',
+  })
+  public playerId: Player;
+}

--- a/server/src/entity/PlayerTeam.ts
+++ b/server/src/entity/PlayerTeam.ts
@@ -1,0 +1,51 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { Player } from './Player';
+import { Team } from './Team';
+
+@Entity('player_team')
+export class PlayerTeam {
+  @Column({
+    default: false,
+    name: 'captain',
+    nullable: false,
+    type: 'boolean',
+  })
+  public captain: boolean;
+
+  @Column({
+    default: false,
+    name: 'co_captain',
+    nullable: false,
+    type: 'boolean',
+  })
+  public coCaptain: boolean;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @ManyToOne(type => Player, player => player.teams, { primary: true })
+  @JoinColumn({
+    name: 'player_id',
+  })
+  public playerId: Player;
+
+  @ManyToOne(type => Team, team => team.players, { primary: true })
+  @JoinColumn({
+    name: 'team_id',
+  })
+  public teamId: Team;
+}

--- a/server/src/entity/Session.ts
+++ b/server/src/entity/Session.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Match } from './Match';
+
+@Entity()
+export class Session {
+  @PrimaryGeneratedColumn({
+    name: 'session_id',
+    type: 'int',
+  })
+  public sessionId: number;
+
+  @Column({
+    length: 10,
+    name: 'session_name',
+    nullable: false,
+  })
+  public sessionName: string;
+
+  @Column({
+    nullable: false,
+    type: 'date',
+  })
+  public year: Date;
+
+  @OneToMany(type => Match, match => match.session)
+  public matches: Match[];
+}

--- a/server/src/entity/SkillLevel.ts
+++ b/server/src/entity/SkillLevel.ts
@@ -1,22 +1,34 @@
-import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 import { Player } from './Player';
 
-@Entity()
+@Entity('skill_level')
 export class SkillLevel {
-  @PrimaryColumn({
+  @PrimaryGeneratedColumn({
     name: 'skill_id',
+    type: 'int',
+  })
+  public skillId: number;
+
+  @Column({
+    name: 'skill_level',
     nullable: false,
     type: 'smallint',
   })
-  skillId: number;
+  public skillLevel: number;
+
+  @Column({
+    length: 20,
+    nullable: false,
+  })
+  public format: string;
 
   @Column({
     name: 'points_required',
     nullable: false,
     type: 'smallint',
   })
-  pointsRequired: number;
+  public pointsRequired: number;
 
   @Column({
     default: 1,
@@ -24,8 +36,8 @@ export class SkillLevel {
     nullable: false,
     type: 'smallint',
   })
-  tournamentTier: number;
+  public tournamentTier: number;
 
   @OneToMany(type => Player, player => player.skillLevel)
-  players: Player[];
+  public players: Player[];
 }

--- a/server/src/entity/Team.ts
+++ b/server/src/entity/Team.ts
@@ -1,0 +1,57 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm';
+
+import { Division } from './Division';
+import { HostLocation } from './HostLocation';
+import { PlayerTeam } from './PlayerTeam';
+import { TeamMatch } from './TeamMatch';
+
+@Entity()
+export class Team {
+  @PrimaryColumn({
+    name: 'team_id',
+    nullable: false,
+    type: 'int',
+  })
+  public teamId: number;
+
+  @Column({
+    length: 50,
+    name: 'team_name',
+    nullable: false,
+  })
+  public teamName: string;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @ManyToOne(type => Division, division => division.teams)
+  @JoinColumn({
+    name: 'division',
+  })
+  public division: Division;
+
+  @ManyToOne(type => HostLocation, hostLocation => hostLocation.teams)
+  @JoinColumn({
+    name: 'host_location',
+  })
+  public hostLocation: HostLocation;
+
+  @OneToMany(type => TeamMatch, teamMatch => teamMatch.teamId)
+  public matches: TeamMatch[];
+
+  @OneToMany(type => PlayerTeam, playerTeam => playerTeam.teamId)
+  public players: PlayerTeam[];
+}

--- a/server/src/entity/TeamMatch.ts
+++ b/server/src/entity/TeamMatch.ts
@@ -1,0 +1,57 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { Match } from './Match';
+import { Team } from './Team';
+
+@Entity('team_match')
+export class TeamMatch {
+  @Column({
+    default: 0,
+    nullable: false,
+    type: 'smallint',
+  })
+  public forfeits: number;
+
+  @Column({
+    default: false,
+    name: 'home_team',
+    nullable: false,
+    type: 'boolean',
+  })
+  public homeTeam: boolean;
+
+  @Column({
+    default: false,
+    nullable: false,
+    type: 'boolean',
+  })
+  public won: boolean;
+
+  @Column({
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'created_at',
+    nullable: false,
+    type: 'timestamptz',
+  })
+  public createdAt: Date;
+
+  @Column({
+    default: null,
+    name: 'updated_at',
+    nullable: true,
+    type: 'timestamptz',
+  })
+  public updatedAt: Date;
+
+  @ManyToOne(type => Match, match => match.teams, { primary: true })
+  @JoinColumn({
+    name: 'match_id',
+  })
+  public matchId: Match;
+
+  @ManyToOne(type => Team, team => team.matches, { primary: true })
+  @JoinColumn({
+    name: 'team_id',
+  })
+  public teamId: Team;
+}


### PR DESCRIPTION
Resolves: #10 
This update creates the remaining entities used by TypeORM to create postgres tables and establishes relations using foreign keys.