### PR TITLE
Fix `get-user.decorator.ts` to prevent error in `getPlayers()`

### DIFF
--- a/server/src/auth/get-user.decorator.ts
+++ b/server/src/auth/get-user.decorator.ts
@@ -1,9 +1,10 @@
-import { createParamDecorator } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 import { User } from './user.entity';
 
 export const GetUser = createParamDecorator(
-  (data, req): User => {
+  (data, ctx: ExecutionContext): User => {
+    const req = ctx.switchToHttp().getRequest();
     return req.user;
   },
 );

--- a/server/src/config/app/config.module.ts
+++ b/server/src/config/app/config.module.ts
@@ -13,12 +13,20 @@ import configuration from './configuration';
       isGlobal: true,
       load: [configuration],
       validationSchema: Joi.object({
+        DB_DATABASE: Joi.string().default('break_n_score'),
+        DB_HOST: Joi.string().default('localhost'),
+        DB_PASS: Joi.string().default('sample_password'),
+        DB_PORT: Joi.number().default(5432),
+        DB_SYNCHRONIZE: Joi.boolean().default(true),
+        DB_TYPE: Joi.string().default('postgres'),
+        DB_USER: Joi.string().default('sample_user'),
+        JWT_EXPIRES: Joi.number().default(3600),
         JWT_SECRET: Joi.string().default('some_secret'),
         NODE_ENV: Joi.string()
           .valid('development', 'production', 'provision', 'test')
           .default('development'),
-        POSTGRES_PASS: Joi.string().default('sample_password'),
-        POSTGRES_USER: Joi.string().default('sample_user'),
+        SERVER_ORIGIN: Joi.string(),
+        SERVER_PORT: Joi.number().default(5000),
       }),
     }),
   ],


### PR DESCRIPTION
This update fixes the `@getUser()` decorator to work with NestJS 7.x. Previously hitting the `/api/player` endpoint with a `GET` request would return an error that `user.email` was not defined.