### PR TITLE
Add PlayerGame endpoint and seed data

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,8 +11,10 @@ import { GameModule } from './game/game.module';
 import { HostLocationModule } from './host-location/host-location.module';
 import { MatchModule } from './match/match.module';
 import { PlayerModule } from './player/player.module';
+import { PlayerGameModule } from './player-game/player-game.module';
 import { PlayerTeamModule } from './player-team/player-team.module';
 import { SessionModule } from './session/session.module';
+import { TeamMatchModule } from './team-match/team-match.module';
 import { TeamModule } from './team/team.module';
 
 const configService = new ConfigService();
@@ -28,9 +30,11 @@ const configSettings = ormConfigService.getConfig();
     GameModule,
     HostLocationModule,
     MatchModule,
+    PlayerGameModule,
     PlayerModule,
     PlayerTeamModule,
     SessionModule,
+    TeamMatchModule,
     TeamModule,
     TypeOrmModule.forRoot(configSettings),
   ],

--- a/server/src/migration/1571907084204-PlayerGameSeed.ts
+++ b/server/src/migration/1571907084204-PlayerGameSeed.ts
@@ -1,0 +1,59 @@
+import { Logger } from '@nestjs/common';
+import { getRepository, MigrationInterface, QueryRunner } from 'typeorm';
+
+import { Game } from '../game/game.entity';
+import { Player } from '../player/player.entity';
+import { PlayerGameSeed } from '../seed/player-game.seed';
+
+export class PlayerGameSeed1571907084204 implements MigrationInterface {
+  private logger = new Logger('PlayerGameSeed');
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    this.logger.log('Starting PlayerGame seed...');
+
+    try {
+      let count = 0;
+
+      for (const playerGame of PlayerGameSeed) {
+        const player = await getRepository<Player>('Player').findOneOrFail(undefined, {
+          where: { id: playerGame.player },
+        });
+        const game = await getRepository<Game>('Game').findOneOrFail(undefined, {
+          where: { id: playerGame.game },
+        });
+        const playerGames = await getRepository('PlayerGame').save({
+          ...playerGame,
+          player,
+          game,
+        });
+
+        if (playerGames) {
+          count++;
+        }
+      }
+
+      if (count > 0) {
+        this.logger.log(`PlayerGame seed completed successfully, ${count} rows added.`);
+      }
+    } catch (error) {
+      this.logger.error('PlayerGame seed failed', error.stack);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    this.logger.log('Starting PlayerGame seed reversion...');
+
+    try {
+      const playerGames = await queryRunner.query('DELETE FROM "player_game"');
+      const rowCount = playerGames[1];
+
+      if (playerGames) {
+        this.logger.log(
+          `PlayerGame seed reversion completed successfully, ${rowCount} rows removed.`,
+        );
+      }
+    } catch (error) {
+      this.logger.error('PlayerGame seed reversion failed', error.stack);
+    }
+  }
+}

--- a/server/src/player-game/dto/create-player-game.dto.ts
+++ b/server/src/player-game/dto/create-player-game.dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsNotEmpty } from 'class-validator';
+
+import { Game } from '../../game/game.entity';
+import { Player } from '../../player/player.entity';
+
+export class CreatePlayerGameDto {
+  @IsInt()
+  @IsNotEmpty()
+  public game: Game;
+
+  @IsInt()
+  @IsNotEmpty()
+  public player: Player;
+}

--- a/server/src/player-game/dto/get-player-games-filter.dto.ts
+++ b/server/src/player-game/dto/get-player-games-filter.dto.ts
@@ -1,0 +1,23 @@
+import { IsNumberString, IsOptional } from 'class-validator';
+
+import { Game } from '../../game/game.entity';
+import { IsBooleanString } from '../../lib/custom.validator';
+import { Player } from '../../player/player.entity';
+
+export class GetPlayerGamesFilterDto {
+  @IsNumberString()
+  @IsOptional()
+  public game?: Game;
+
+  @IsNumberString()
+  @IsOptional()
+  public player?: Player;
+
+  @IsBooleanString()
+  @IsOptional()
+  public skunk?: boolean;
+
+  @IsBooleanString()
+  @IsOptional()
+  public won?: boolean;
+}

--- a/server/src/player-game/dto/update-player-game.dto.ts
+++ b/server/src/player-game/dto/update-player-game.dto.ts
@@ -1,0 +1,35 @@
+import { IsBoolean, IsInt, IsOptional } from 'class-validator';
+
+export class UpdatePlayerGameDto {
+  @IsInt()
+  @IsOptional()
+  public breakAndRun?: number;
+
+  @IsInt()
+  @IsOptional()
+  public defense?: number;
+
+  @IsInt()
+  @IsOptional()
+  public nineOnSnap?: number;
+
+  @IsInt()
+  @IsOptional()
+  public playerScore?: number;
+
+  @IsInt()
+  @IsOptional()
+  public pointsScored?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  public skunk?: boolean;
+
+  @IsInt()
+  @IsOptional()
+  public timeouts?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  public won?: boolean;
+}

--- a/server/src/player-game/player-game.controller.ts
+++ b/server/src/player-game/player-game.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Logger,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+import { GetUser } from '../auth/get-user.decorator';
+import { User } from '../auth/user.entity';
+import { CreatePlayerGameDto } from './dto/create-player-game.dto';
+import { GetPlayerGamesFilterDto } from './dto/get-player-games-filter.dto';
+import { UpdatePlayerGameDto } from './dto/update-player-game.dto';
+import { PlayerGame } from './player-game.entity';
+import { PlayerGameService } from './player-game.service';
+
+@Controller('api/player-game')
+@UseGuards(AuthGuard())
+export class PlayerGameController {
+  constructor(private playerGameService: PlayerGameService) {}
+
+  private logger = new Logger('PlayerGameController');
+
+  @Post()
+  @UsePipes(ValidationPipe)
+  public createPlayerGame(
+    @Body() createPlayerGameDto: CreatePlayerGameDto,
+    @GetUser() user: User,
+  ): Promise<PlayerGame> {
+    this.logger.verbose(
+      `User "${user.email}" creating a new player game. Data: ${JSON.stringify(
+        createPlayerGameDto,
+      )}`,
+    );
+    return this.playerGameService.createPlayerGame(createPlayerGameDto, user);
+  }
+
+  @Delete('/:id')
+  public deletePlayerGame(
+    @Param('id', ParseIntPipe) id: number,
+    @GetUser() user: User,
+  ): Promise<void> {
+    this.logger.verbose(`User "${user.email}" deleting a player game. Player game: ${id}`);
+    return this.playerGameService.deletePlayerGame(id);
+  }
+
+  @Get('/:id')
+  public getPlayerGameById(
+    @Param('id', ParseIntPipe) id: number,
+    @GetUser() user: User,
+  ): Promise<PlayerGame> {
+    return this.playerGameService.getPlayerGameById(id);
+  }
+
+  @Get()
+  public getPlayerGames(
+    @Query(ValidationPipe) filterDto: GetPlayerGamesFilterDto,
+    @GetUser() user: User,
+  ): Promise<PlayerGame[]> {
+    this.logger.verbose(
+      `User "${user.email}" retrieving all player games. Filters: ${JSON.stringify(filterDto)}`,
+    );
+    return this.playerGameService.getPlayerGames(filterDto, user);
+  }
+
+  @Patch('/:id')
+  public updatePlayerGame(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updatePlayerGameDto: UpdatePlayerGameDto,
+    @GetUser() user: User,
+  ): Promise<PlayerGame> {
+    return this.playerGameService.updatePlayerGame(id, updatePlayerGameDto);
+  }
+}

--- a/server/src/player-game/player-game.module.ts
+++ b/server/src/player-game/player-game.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { AuthModule } from '../auth/auth.module';
+import { GameRepository } from '../game/game.repository';
+import { PlayerRepository } from '../player/player.repository';
+import { PlayerGameController } from './player-game.controller';
+import { PlayerGameRepository } from './player-game.repository';
+import { PlayerGameService } from './player-game.service';
+
+@Module({
+  controllers: [PlayerGameController],
+  imports: [
+    AuthModule,
+    TypeOrmModule.forFeature([GameRepository, PlayerGameRepository, PlayerRepository]),
+  ],
+  providers: [PlayerGameService],
+})
+export class PlayerGameModule {}

--- a/server/src/player-game/player-game.repository.ts
+++ b/server/src/player-game/player-game.repository.ts
@@ -1,0 +1,76 @@
+import {
+  ConflictException,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { EntityRepository, Repository } from 'typeorm';
+
+import { User } from '../auth/user.entity';
+import { duplicateEntryErrorCode } from '../auth/user.repository';
+import { CreatePlayerGameDto } from './dto/create-player-game.dto';
+import { GetPlayerGamesFilterDto } from './dto/get-player-games-filter.dto';
+import { PlayerGame } from './player-game.entity';
+
+@EntityRepository(PlayerGame)
+export class PlayerGameRepository extends Repository<PlayerGame> {
+  private logger = new Logger('PlayerGameRepository');
+
+  public async createPlayerGame(
+    createPlayerGameDto: CreatePlayerGameDto,
+    user: User,
+  ): Promise<PlayerGame> {
+    const { game, player } = createPlayerGameDto;
+
+    const playerGame = new PlayerGame();
+    playerGame.game = game;
+    playerGame.player = player;
+
+    try {
+      await playerGame.save();
+    } catch (error) {
+      this.logger.error(
+        `Failed to create player game for user "${user.email}". Data: ${JSON.stringify(
+          createPlayerGameDto,
+        )}`,
+        error.stack,
+      );
+      // TODO: Make sure that this error is still the same when it's a primary key violation and not uniqueness violation
+      if (error.code === duplicateEntryErrorCode) {
+        throw new ConflictException('PlayerGame player/game combination already exists');
+      } else {
+        throw new InternalServerErrorException();
+      }
+    }
+
+    return playerGame;
+  }
+
+  public async getPlayerGames(
+    getPlayerGamesFilterDto: GetPlayerGamesFilterDto,
+    user: User,
+  ): Promise<PlayerGame[]> {
+    const { game, player } = getPlayerGamesFilterDto;
+    const query = this.createQueryBuilder('player_game')
+      .innerJoinAndSelect('player_game.player', 'player')
+      .innerJoinAndSelect('player_game.game', 'game');
+
+    if (game) {
+      query.where('player_game.game = :game', { game });
+    } else if (player) {
+      query.where('player_game.player = :player', { player });
+    }
+
+    try {
+      return query.getMany();
+    } catch (error) {
+      this.logger.error(
+        `Failed to get player games for user "${user.email}". Filters: ${JSON.stringify(
+          getPlayerGamesFilterDto,
+        )}`,
+        error.stack,
+      );
+      throw new NotFoundException();
+    }
+  }
+}

--- a/server/src/player-game/player-game.service.ts
+++ b/server/src/player-game/player-game.service.ts
@@ -1,0 +1,193 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as _ from 'lodash';
+
+import { PlayerRepository } from '../player/player.repository';
+import { GameRepository } from '../game/game.repository';
+import { PlayerGameRepository } from './player-game.repository';
+
+import type { User } from '../auth/user.entity';
+import type { CreatePlayerGameDto } from './dto/create-player-game.dto';
+import type { GetPlayerGamesFilterDto } from './dto/get-player-games-filter.dto';
+import type { UpdatePlayerGameDto } from './dto/update-player-game.dto';
+import type { PlayerGame } from './player-game.entity';
+
+@Injectable()
+export class PlayerGameService {
+  constructor(
+    @InjectRepository(PlayerRepository)
+    private playerRepository: PlayerRepository,
+    @InjectRepository(PlayerGameRepository)
+    private playerGameRepository: PlayerGameRepository,
+    @InjectRepository(GameRepository)
+    private gameRepository: GameRepository,
+  ) {}
+
+  public async createPlayerGame(
+    createPlayerGameDto: CreatePlayerGameDto,
+    user: User,
+  ): Promise<PlayerGame> {
+    const { game, player } = createPlayerGameDto;
+    const relatedGame = await this.gameRepository.getGame(game);
+    const relatedPlayer = await this.playerRepository.getPlayer(player);
+
+    if (_.isUndefined(relatedGame)) {
+      throw new NotFoundException(`Game "${game}" not found`);
+    }
+
+    if (_.isUndefined(relatedPlayer)) {
+      throw new NotFoundException(`Player "${player}" not found`);
+    }
+    // TODO: Finish hammering out this f'd up relation to get the PlayerTeam and Team info
+    const otherPlayerInGame = await this.playerGameRepository
+      .createQueryBuilder('player_game')
+      .select('player_game.id')
+      .addSelect('player.format')
+      .addSelect('player_team.id')
+      .addSelect('team.id')
+      .addSelect('game.id')
+      .addSelect('match.id')
+      .addSelect('team_match.id')
+      .innerJoin('player_game.player', 'player')
+      .innerJoin('player_game.game', 'game')
+      .innerJoin('game.match', 'match')
+      .innerJoin('match.teams', 'team_match')
+      .innerJoin('team_match.team', 'team')
+      .innerJoin('player.teams', 'player_team')
+      .where('player_game.game = :game', { game: relatedGame.id })
+      .andWhere('player_game.player != :player', { player: relatedPlayer.id })
+      .andWhere('player_team.team.id = team.id')
+      .getOne();
+    const arePlayersOnTheSameTeam = relatedPlayer.teams.some(
+      ({ team }) => team.id === otherPlayerInGame?.game.match.teams[0].team.id,
+    );
+    // TODO: Add logic to compare list of teams in match with list of teams relatedPlayer is in to ensure player's team is not already in this game
+    if (
+      !_.isUndefined(otherPlayerInGame) &&
+      otherPlayerInGame.player.format !== relatedPlayer.format
+    ) {
+      throw new UnprocessableEntityException(`Player's format does not match other player in game`);
+    }
+
+    if (arePlayersOnTheSameTeam) {
+      throw new UnprocessableEntityException('Both players are on the same team!');
+    }
+
+    const playerGamesInSameMatch = await this.playerGameRepository
+      .createQueryBuilder('player_game')
+      .select('player_game.id')
+      .addSelect('game.id')
+      .addSelect('player.id')
+      .addSelect('match.id')
+      .innerJoin('player_game.game', 'game')
+      .innerJoin('player_game.player', 'player')
+      .innerJoin('game.match', 'match')
+      .where('game.match = :match', { match: relatedGame.match.id })
+      .getMany();
+    const isPlayerAlreadyInGame = playerGamesInSameMatch.some(
+      playerGame =>
+        playerGame.game.id === relatedGame.id && playerGame.player.id === relatedPlayer.id,
+    );
+    const playerGamesForRelatedPlayer = playerGamesInSameMatch.filter(
+      playerGame => playerGame.player.id === relatedPlayer.id,
+    );
+    const hasPlayerAlreadyPlayedTwice = playerGamesForRelatedPlayer.length === 2;
+    const playerGamesForRelatedGame = playerGamesInSameMatch.filter(
+      playerGame => playerGame.game.id === relatedGame.id,
+    );
+    const doesGameAlreadyHaveTwoPlayers = playerGamesForRelatedGame.length === 2;
+
+    if (isPlayerAlreadyInGame) {
+      throw new ConflictException('Player is already in this game!');
+    }
+
+    if (hasPlayerAlreadyPlayedTwice) {
+      throw new ConflictException('Player has already played 2 games in this match');
+    }
+
+    if (doesGameAlreadyHaveTwoPlayers) {
+      throw new ConflictException('There are already 2 players in this game');
+    }
+
+    createPlayerGameDto.game = relatedGame;
+    createPlayerGameDto.player = relatedPlayer;
+
+    return this.playerGameRepository.createPlayerGame(createPlayerGameDto, user);
+  }
+
+  public async deletePlayerGame(id: number): Promise<void> {
+    const result = await this.playerGameRepository.delete({ id });
+
+    if (result.affected === 0) {
+      throw new NotFoundException(`PlayerGame with ID "${id}" not found`);
+    }
+  }
+
+  public async getPlayerGameById(id: number): Promise<PlayerGame> {
+    const playerGame = await this.playerGameRepository.findOne({
+      relations: ['game', 'player'],
+      where: { id },
+    });
+
+    if (_.isUndefined(playerGame)) {
+      throw new NotFoundException(`PlayerGame with ID "${id}" not found`);
+    }
+
+    return playerGame;
+  }
+
+  public async getPlayerGames(
+    filterDto: GetPlayerGamesFilterDto,
+    user: User,
+  ): Promise<PlayerGame[]> {
+    return this.playerGameRepository.getPlayerGames(filterDto, user);
+  }
+
+  public async updatePlayerGame(
+    id: number,
+    updatePlayerGameDto: UpdatePlayerGameDto,
+  ): Promise<PlayerGame> {
+    const {
+      breakAndRun,
+      defense,
+      nineOnSnap,
+      playerScore,
+      pointsScored,
+      skunk,
+      won,
+    } = updatePlayerGameDto;
+    const playerGame = await this.getPlayerGameById(id);
+    const otherPlayerInGame = await this.playerGameRepository
+      .createQueryBuilder('player_game')
+      .select('player_game.skunk')
+      .addSelect('player_game.won')
+      .where('player_game.game = :game', { game: playerGame.game.id })
+      .andWhere('player_game.player != :player', { player: playerGame.player.id })
+      .getOne();
+
+    if (!_.isNil(skunk) && skunk && otherPlayerInGame?.skunk === skunk) {
+      throw new ConflictException('Only one player can achieve a skunk for this game');
+    }
+
+    if (!_.isNil(won) && won && otherPlayerInGame?.won === won) {
+      throw new ConflictException('Only one player can be set as the winner for this game');
+    }
+
+    playerGame.breakAndRun = breakAndRun || playerGame.breakAndRun;
+    playerGame.defense = defense || playerGame.defense;
+    playerGame.nineOnSnap = nineOnSnap || playerGame.nineOnSnap;
+    playerGame.playerScore = playerScore || playerGame.playerScore;
+    playerGame.pointsScored = pointsScored || playerGame.pointsScored;
+    playerGame.skunk = skunk ?? playerGame.skunk;
+    playerGame.updatedAt = new Date(Date.now());
+    playerGame.won = won ?? playerGame.won;
+
+    await playerGame.save();
+    return playerGame;
+  }
+}

--- a/server/src/seed/player-game.seed.ts
+++ b/server/src/seed/player-game.seed.ts
@@ -1,0 +1,155 @@
+import { StrictOmit } from 'ts-essentials';
+
+import { PlayerGame } from '../player-game/player-game.entity';
+
+export type PlayerGameSeedEntity = StrictOmit<PlayerGame, 'game' | 'player'> & {
+  game: number;
+  player: number;
+};
+
+export const PlayerGameSeed: Array<Partial<PlayerGameSeedEntity>> = [
+  {
+    game: 1,
+    player: 3,
+  },
+  {
+    game: 1,
+    player: 5,
+  },
+  {
+    game: 2,
+    player: 9,
+  },
+  {
+    game: 2,
+    player: 11,
+  },
+  {
+    game: 3,
+    player: 4,
+  },
+  {
+    game: 3,
+    player: 6,
+  },
+  {
+    game: 4,
+    player: 10,
+  },
+  {
+    game: 4,
+    player: 12,
+  },
+  {
+    game: 5,
+    player: 2,
+  },
+  {
+    game: 5,
+    player: 6,
+  },
+  {
+    game: 6,
+    player: 8,
+  },
+  {
+    game: 6,
+    player: 12,
+  },
+  {
+    game: 7,
+    player: 1,
+  },
+  {
+    game: 7,
+    player: 5,
+  },
+  {
+    game: 8,
+    player: 7,
+  },
+  {
+    game: 8,
+    player: 11,
+  },
+  {
+    game: 9,
+    player: 2,
+  },
+  {
+    game: 9,
+    player: 6,
+  },
+  {
+    game: 10,
+    player: 8,
+  },
+  {
+    game: 10,
+    player: 12,
+  },
+  {
+    game: 11,
+    player: 2,
+  },
+  {
+    game: 11,
+    player: 4,
+  },
+  {
+    game: 12,
+    player: 8,
+  },
+  {
+    game: 12,
+    player: 10,
+  },
+  {
+    game: 13,
+    player: 1,
+  },
+  {
+    game: 13,
+    player: 3,
+  },
+  {
+    game: 14,
+    player: 7,
+  },
+  {
+    game: 14,
+    player: 9,
+  },
+  {
+    game: 15,
+    player: 2,
+  },
+  {
+    game: 15,
+    player: 4,
+  },
+  {
+    game: 16,
+    player: 8,
+  },
+  {
+    game: 16,
+    player: 10,
+  },
+  {
+    game: 17,
+    player: 4,
+  },
+  {
+    game: 17,
+    player: 6,
+  },
+  {
+    game: 18,
+    player: 10,
+  },
+  {
+    game: 18,
+    player: 12,
+  },
+];

--- a/server/src/team-match/team-match.service.ts
+++ b/server/src/team-match/team-match.service.ts
@@ -149,9 +149,6 @@ export class TeamMatchService {
       .createQueryBuilder('team_match')
       .select('team_match.homeTeam')
       .addSelect('team_match.won')
-      .addSelect('division.id')
-      .innerJoinAndSelect('team_match.team', 'team')
-      .innerJoin('team.division', 'division')
       .where('team_match.match = :match', { match: teamMatch.match.id })
       .andWhere('team_match.team != :team', { team: teamMatch.team.id })
       .getOne();


### PR DESCRIPTION
This update adds the module, repository, controller, and service for the `PlayerGame` entity. It also adds a migration script and seed data to pre-populate some test data. This update also makes the following unrelated changes:
- Remove joins and unnecessary column from query in `updateTeamMatch()`.
- Add logic checks in `updatePlayerTeam()` to ensure only one player can be captain/co-captain.

Resolves: #16 